### PR TITLE
Add technology detail pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,5 @@
 - Added project roadmap in docs/ROADMAP.md.
 - Implemented MVP features: technology dataset, explorer with search and
   filtering, stack wizard, and basic UI.
+- Added technology detail pages linked from the catalog.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -58,7 +58,7 @@ This document outlines the long‐term plan for the Tech Stack Explorer and Pick
    - [x] Initial hosting setup.
 2. **Enhancing Data and Detail**
    - [ ] Expand technology database and metadata.
-   - [ ] Add detail pages with rich content.
+   - [x] Add detail pages with rich content.
    - [ ] Improve filtering and search accuracy.
 3. **User Engagement Features**
    - [ ] Accounts for saving stacks and preferences.

--- a/src/app/technologies/[id]/page.tsx
+++ b/src/app/technologies/[id]/page.tsx
@@ -1,0 +1,39 @@
+import { getTechnologyById } from '@/lib/technologyUtils';
+import { notFound } from 'next/navigation';
+
+export default function TechnologyDetail({ params }: { params: { id: string } }) {
+  const tech = getTechnologyById(params.id);
+  if (!tech) return notFound();
+
+  return (
+    <div className="container mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-bold text-[rgb(var(--foreground-rgb))]">
+        {tech.name}
+      </h1>
+      <p className="text-[rgb(var(--muted-rgb))]">{tech.description}</p>
+      <p>
+        <strong>Category:</strong> {tech.category}
+      </p>
+      <p>
+        <strong>Tags:</strong> {tech.tags.join(', ')}
+      </p>
+      {tech.website && (
+        <p>
+          <a
+            href={tech.website}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[rgb(var(--primary-rgb))] hover:underline"
+          >
+            Visit Website
+          </a>
+        </p>
+      )}
+    </div>
+  );
+}
+
+export async function generateStaticParams() {
+  const { default: technologies } = await import('@/data/technologies.json');
+  return (technologies as { id: string }[]).map((t) => ({ id: t.id }));
+}

--- a/src/components/TechCard.tsx
+++ b/src/components/TechCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Link from 'next/link';
 import { ITechnology } from '../types'; // Assuming types is in src/types
 
 interface TechCardProps {
@@ -28,7 +29,11 @@ const TechCard: React.FC<TechCardProps> = ({ technology /*, viewMode */ }) => {
             {getInitials(technology.name)}
           </div>
         )}
-        <h3 className="text-xl font-bold text-gray-800 dark:text-gray-100 mt-0">{technology.name}</h3>
+        <h3 className="text-xl font-bold text-gray-800 dark:text-gray-100 mt-0">
+          <Link href={`/technologies/${technology.id}`} className="hover:underline">
+            {technology.name}
+          </Link>
+        </h3>
       </div>
 
       <p className="text-sm text-gray-600 dark:text-gray-300 mb-3 text-ellipsis overflow-hidden flex-grow">

--- a/src/lib/technologyUtils.test.ts
+++ b/src/lib/technologyUtils.test.ts
@@ -1,0 +1,19 @@
+import { getTechnologyById } from './technologyUtils';
+import { ITechnology } from '@/types';
+
+describe('getTechnologyById', () => {
+  const sample: ITechnology[] = [
+    { id: 'react', name: 'React', description: 'JS UI', tags: [], category: 'lib' },
+    { id: 'node', name: 'Node.js', description: 'JS runtime', tags: [], category: 'platform' },
+  ];
+
+  it('returns matching technology', () => {
+    const tech = getTechnologyById('react', sample);
+    expect(tech?.name).toBe('React');
+  });
+
+  it('returns undefined for unknown id', () => {
+    const tech = getTechnologyById('unknown', sample);
+    expect(tech).toBeUndefined();
+  });
+});

--- a/src/lib/technologyUtils.ts
+++ b/src/lib/technologyUtils.ts
@@ -1,0 +1,9 @@
+import technologiesData from '@/data/technologies.json';
+import { ITechnology } from '@/types';
+
+export const getTechnologyById = (
+  id: string,
+  data: ITechnology[] = technologiesData as ITechnology[]
+): ITechnology | undefined => {
+  return data.find((tech) => tech.id === id);
+};


### PR DESCRIPTION
## Summary
- link tech cards to new detail pages
- add Technology detail route
- utility and test for retrieving a technology by id
- document detail pages in roadmap
- record changes in changelog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853e8023b94833285c850f10f4c8f8b